### PR TITLE
Added commenting

### DIFF
--- a/Comments.tmPreferences
+++ b/Comments.tmPreferences
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<plist version="1.0">
+<dict>
+    <key>name</key>
+    <string>Comments</string>
+    <key>scope</key>
+    <string>text.markdeep</string>
+    <key>settings</key>
+    <dict>
+        <key>shellVariables</key>
+        <array>
+            <dict>
+                <key>name</key>
+                <string>TM_COMMENT_START</string>
+                <key>value</key>
+                <string><![CDATA[<!-- ]]></string>
+            </dict>
+            <dict>
+                <key>name</key>
+                <string>TM_COMMENT_END</string>
+                <key>value</key>
+                <string><![CDATA[ -->]]></string>
+            </dict>
+        </array>
+    </dict>
+</dict>
+</plist>


### PR DESCRIPTION
Enables commenting shortcuts ("Ctrl + /" and "Ctrl + Shift + /" by default). The behavior is identical to built-in HTML syntax settings.
